### PR TITLE
Add Dispose For Default Deferred Pointer Handler Link

### DIFF
--- a/lib/deferred_pointer_handler.dart
+++ b/lib/deferred_pointer_handler.dart
@@ -33,6 +33,13 @@ class DeferredPointerHandlerState extends State<DeferredPointerHandler> {
   }
 
   @override
+  void dispose()
+  {
+    _link.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return _InheritedDeferredPaintSurface(
       state: this,


### PR DESCRIPTION
## Overview
I discovered when integrating [leak tracking](https://github.com/dart-lang/leak_tracker), the default Deferred Handler Link was not being disposed. No other widgets have ownership of this link, and must be disposed on this state's disposal.

This PR adds dispose to the DeferredPointerHandlerState when the widget is disposed to dispose the default link.

Fixes https://github.com/gskinnerTeam/flutter-defer-pointer/issues/12