### PR TITLE
Fix Memory Leak From Default Link

### DIFF
--- a/lib/deferred_pointer_handler.dart
+++ b/lib/deferred_pointer_handler.dart
@@ -39,6 +39,12 @@ class DeferredPointerHandlerState extends State<DeferredPointerHandler> {
       child: _DeferredHitTargetRenderObjectWidget(link: widget.link ?? _link, child: widget.child),
     );
   }
+
+  @override
+  void dispose() {
+    _link.dispose();
+    super.dispose();
+  }
 }
 
 ////////////////////////////////


### PR DESCRIPTION
## Overview
The default link needs to be disposed when this handler widget state is disposed since it's owned here with no other hooks.
This can cause a subscriber list leak since it's a change notifier.